### PR TITLE
Fix Google Drive download

### DIFF
--- a/omnitils/api/gdrive.py
+++ b/omnitils/api/gdrive.py
@@ -263,7 +263,7 @@ def gdrive_download_file(
             f'{path.name} | {url}')
 
     # Rename temporary file
-    if not os.path.samefile(file, path):
+    if not (path.is_file() and os.path.samefile(file, path)):
         shutil.move(file, path)
 
     # Close session and return

--- a/omnitils/files/_core.py
+++ b/omnitils/files/_core.py
@@ -47,9 +47,10 @@ def get_temporary_file(path: Path, ext: str = '.tmp', allow_existing: bool = Fal
     # Look for an existing file
     temp = path.with_suffix(ext)
     if allow_existing:
+        path_exists = path.is_file()
         for p in os.listdir(path.parent):
             file = path.parent / p
-            if file.is_dir() or os.path.samefile(file, path):
+            if file.is_dir() or (path_exists and os.path.samefile(file, path)):
                 continue
             if temp.name in file.name:
                 return file


### PR DESCRIPTION
The Google Drive download logic can pass a non-existent file to `os.path.samefile`, which doesn't work. This pull request adds checks to avoid such calls.